### PR TITLE
Replace emoji icons with Lucide icons in dashboard and sidebar

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { AuthGuard } from "@/components/AuthGuard";
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
+import { Package, Hourglass, HandCoins } from "lucide-react";
 
 interface DashboardStats {
   totalOrders: number;
@@ -29,18 +30,13 @@ export default function DashboardPage() {
   useEffect(() => {
     const fetchStats = async () => {
       try {
-        const { data: orders, error } = await supabase
-          .from("orders")
-          .select("*");
+        const { data: orders, error } = await supabase.from("orders").select("*");
 
         if (error) throw error;
 
         const totalOrders = orders?.length || 0;
-        const pendingOrders =
-          orders?.filter((o) => o.status === "pending").length || 0;
-        const totalRevenue =
-          orders?.reduce((sum, order) => sum + (order.total_price || 0), 0) ||
-          0;
+        const pendingOrders = orders?.filter((o) => o.status === "pending").length || 0;
+        const totalRevenue = orders?.reduce((sum, order) => sum + (order.total_price || 0), 0) || 0;
 
         setStats({ totalOrders, pendingOrders, totalRevenue });
       } catch (error) {
@@ -65,32 +61,34 @@ export default function DashboardPage() {
   return (
     <AuthGuard>
       <div className="p-6">
-        {/* Powitanie */}
+        {/* Greeting */}
         <div className="mb-8">
-          <h1 className="text-2xl font-bold mb-2">
-            Witaj, {user?.email?.split("@")[0] || "Użytkowniku"}! 👋
-          </h1>
-          <p className="text-muted-foreground">
-            Oto przegląd Twojego panelu administracyjnego
-          </p>
+          <h1 className="text-2xl font-bold mb-2">Witaj, {user?.email?.split("@")[0] || "Użytkowniku"}!</h1>
+          <p className="text-muted-foreground">Oto przegląd Twojego panelu administracyjnego:</p>
         </div>
 
-        {/* Statystyki */}
+        {/* Stats */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
           <div className="bg-card p-6 rounded-lg border border-border">
-            <div className="text-4xl mb-2">📦</div>
+            <div className="text-4xl mb-2 text-primary">
+              <Package className="w-10 h-10" />
+            </div>
             <h3 className="text-lg font-medium mb-1">Wszystkie zamówienia</h3>
             <p className="text-2xl font-bold">{stats.totalOrders}</p>
           </div>
 
           <div className="bg-card p-6 rounded-lg border border-border">
-            <div className="text-4xl mb-2">⏳</div>
+            <div className="text-4xl mb-2 text-primary">
+              <Hourglass className="w-10 h-10" />
+            </div>
             <h3 className="text-lg font-medium mb-1">Oczekujące</h3>
             <p className="text-2xl font-bold">{stats.pendingOrders}</p>
           </div>
 
           <div className="bg-card p-6 rounded-lg border border-border">
-            <div className="text-4xl mb-2">💰</div>
+            <div className="text-4xl mb-2 text-primary">
+              <HandCoins className="w-10 h-10" />
+            </div>
             <h3 className="text-lg font-medium mb-1">Przychód</h3>
             <p className="text-2xl font-bold">
               {stats.totalRevenue.toLocaleString("pl-PL", {
@@ -101,7 +99,7 @@ export default function DashboardPage() {
           </div>
         </div>
 
-        {/* Ostatnie aktywności */}
+        {/* Recent activity */}
         <div className="bg-card rounded-lg border border-border p-6">
           <h2 className="text-xl font-bold mb-4">Ostatnie aktywności</h2>
           <div className="space-y-4">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,11 +5,12 @@ import Link from "next/link";
 import { useAuth } from "@/hooks/useAuth";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
+import { BarChart2, Package, User, LogOut, Store } from "lucide-react";
 
 const menuItems = [
-  { href: "/dashboard", label: "Dashboard", icon: "📊" },
-  { href: "/orders", label: "Zamówienia", icon: "📦" },
-  { href: "/profile", label: "Profil", icon: "👤" },
+  { href: "/dashboard", label: "Dashboard", icon: <BarChart2 className="w-5 h-5" /> },
+  { href: "/orders", label: "Zamówienia", icon: <Package className="w-5 h-5" /> },
+  { href: "/profile", label: "Profil", icon: <User className="w-5 h-5" /> },
 ];
 
 export default function Sidebar() {
@@ -20,26 +21,16 @@ export default function Sidebar() {
   return (
     <>
       {/* Przycisk do pokazywania/ukrywania na mobilnych */}
-      <button
-        className="lg:hidden fixed top-4 left-4 z-50 p-2 bg-primary text-white rounded-md"
-        onClick={() => setIsCollapsed(!isCollapsed)}
-      >
+      <button className="lg:hidden fixed top-4 left-4 z-50 p-2 bg-primary text-white rounded-md" onClick={() => setIsCollapsed(!isCollapsed)}>
         {isCollapsed ? "☰" : "✕"}
       </button>
 
       {/* Sidebar */}
-      <aside
-        className={cn(
-          "fixed top-0 left-0 h-screen bg-card border-r border-border transition-all duration-300 z-40",
-          isCollapsed ? "-translate-x-full" : "translate-x-0",
-          "lg:translate-x-0",
-          isCollapsed ? "w-0" : "w-64"
-        )}
-      >
+      <aside className={cn("fixed top-0 left-0 h-screen bg-card border-r border-border transition-all duration-300 z-40", isCollapsed ? "-translate-x-full" : "translate-x-0", "lg:translate-x-0", isCollapsed ? "w-0" : "w-64")}>
         <div className="flex flex-col h-full p-4">
           {/* Logo/Nazwa */}
           <div className="flex items-center gap-2 mb-8 px-2">
-            <span className="text-2xl font-bold text-primary">🏪</span>
+            <Store className="w-7 h-7 text-primary" />
             <h1 className="text-xl font-bold">Budy Admin</h1>
           </div>
 
@@ -48,16 +39,7 @@ export default function Sidebar() {
             <ul className="space-y-2">
               {menuItems.map((item) => (
                 <li key={item.href}>
-                  <Link
-                    href={item.href}
-                    className={cn(
-                      "flex items-center gap-3 px-3 py-2 rounded-md transition-colors",
-                      "hover:bg-muted",
-                      pathname === item.href
-                        ? "bg-primary/10 text-primary"
-                        : "text-foreground"
-                    )}
-                  >
+                  <Link href={item.href} className={cn("flex items-center gap-3 px-3 py-2 rounded-md transition-colors", "hover:bg-muted", pathname === item.href ? "bg-primary/10 text-primary" : "text-foreground")}>
                     <span className="text-xl">{item.icon}</span>
                     <span>{item.label}</span>
                   </Link>
@@ -69,18 +51,13 @@ export default function Sidebar() {
           {/* Profil użytkownika */}
           <div className="border-t border-border pt-4 mt-4">
             <div className="flex items-center gap-3 px-3 py-2">
-              <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
-                {user?.email?.[0]?.toUpperCase() || "?"}
-              </div>
+              <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">{user?.email?.[0]?.toUpperCase() || "?"}</div>
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium truncate">{user?.email}</p>
               </div>
             </div>
-            <button
-              onClick={signOut}
-              className="w-full mt-2 px-3 py-2 text-sm text-red-500 hover:bg-red-50 dark:hover:bg-red-950/50 rounded-md transition-colors text-left flex items-center gap-2"
-            >
-              <span>🚪</span>
+            <button onClick={signOut} className="w-full mt-2 px-3 py-2 text-sm text-red-500 hover:bg-red-50 dark:hover:bg-red-950/50 rounded-md transition-colors text-left flex items-center gap-2">
+              <LogOut className="w-5 h-5" />
               <span>Wyloguj się</span>
             </button>
           </div>
@@ -88,12 +65,7 @@ export default function Sidebar() {
       </aside>
 
       {/* Overlay na mobilnych */}
-      {!isCollapsed && (
-        <div
-          className="fixed inset-0 bg-black/50 z-30 lg:hidden"
-          onClick={() => setIsCollapsed(true)}
-        />
-      )}
+      {!isCollapsed && <div className="fixed inset-0 bg-black/50 z-30 lg:hidden" onClick={() => setIsCollapsed(true)} />}
     </>
   );
 }


### PR DESCRIPTION
Updated the dashboard stats and sidebar navigation to use Lucide React icons instead of emoji icons for a more consistent and professional UI.

Closes #13 