### PR TITLE
Add search functionality to orders page

### DIFF
--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -22,6 +22,7 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const status = searchParams.get("status");
   const size = searchParams.get("size");
+  const search = searchParams.get("search");
 
   let query = supabase.from("orders").select("*");
 
@@ -46,7 +47,15 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  const orders = (data ?? []).map((order) => parseJsonFields(order, ["size", "delivery_option", "payment_method", "contact_info", "additional_options"]));
+  let orders = (data ?? []).map((order) => parseJsonFields(order, ["size", "delivery_option", "payment_method", "contact_info", "additional_options"]));
+
+  if (search) {
+    const term = search.toLowerCase();
+    orders = orders.filter((order) => {
+      const orderString = JSON.stringify(order).toLowerCase();
+      return orderString.includes(term);
+    });
+  }
 
   return NextResponse.json({ orders });
 }

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -4,10 +4,15 @@ import { useOrders } from "@/hooks/useOrders";
 import { TableHeaderRow } from "@/components/orders/TableHeaderRow";
 import { OrderRow } from "@/components/orders/OrderRow";
 import { AuthGuard } from "@/components/AuthGuard";
+import { Input } from "@/components/ui/input";
+import { useDebounce } from "@/hooks/useDebounce";
+import { Search, X } from "lucide-react";
 
 export default function OrdersPage() {
   const [statusFilter, setStatusFilter] = useState<string | null>(null);
   const [productFilter, setProductFilter] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const debouncedSearchTerm = useDebounce(searchTerm, 350);
   const [sortKey, setSortKey] = useState<"created_at" | "status" | "size" | "total_price" | null>("created_at");
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
   const [statusSortDirection, setStatusSortDirection] = useState<"asc" | "desc">("asc");
@@ -20,6 +25,7 @@ export default function OrdersPage() {
   const { orders, loading, error } = useOrders({
     status: statusFilter ?? undefined,
     size: productFilter ?? undefined,
+    search: debouncedSearchTerm || undefined,
   });
 
   const allStatuses = useMemo(() => Array.from(new Set(orders.map((o) => o.status).filter(Boolean))).sort(), [orders]);
@@ -92,6 +98,11 @@ export default function OrdersPage() {
       <div className="p-6">
         <div className="flex justify-between items-center mb-6">
           <h1 className="text-2xl font-bold">Zamówienia</h1>
+          <div className="relative w-100">
+            <Input placeholder="Szukaj zamówień..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} className="pl-8 pr-8" />
+            <Search className="absolute left-2.5 top-3 h-4 w-4 text-muted-foreground" />
+            {searchTerm && <X className="absolute right-2.5 top-3 h-4 w-4 text-muted-foreground cursor-pointer" onClick={() => setSearchTerm("")} />}
+          </div>
         </div>
 
         {error && <div className="mb-6 p-4 bg-red-100 border border-red-400 text-red-700 rounded-md">Błąd: {error}</div>}

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce<T>(value: T, delay?: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay || 500);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -4,9 +4,10 @@ import { UIOrder } from "@/types/UIOrder";
 type UseOrdersParams = {
   status?: string;
   size?: string;
+  search?: string;
 };
 
-export function useOrders({ status, size }: UseOrdersParams) {
+export function useOrders({ status, size, search }: UseOrdersParams) {
   const [orders, setOrders] = useState<UIOrder[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -20,6 +21,7 @@ export function useOrders({ status, size }: UseOrdersParams) {
         const params = new URLSearchParams();
         if (status) params.append("status", status);
         if (size) params.append("size", size);
+        if (search) params.append("search", search);
 
         const res = await fetch(`/api/orders?${params.toString()}`);
         const json = await res.json();
@@ -38,7 +40,7 @@ export function useOrders({ status, size }: UseOrdersParams) {
     };
 
     fetchOrders();
-  }, [status, size]);
+  }, [status, size, search]);
 
   return { orders, loading, error };
 }


### PR DESCRIPTION
Introduces a debounced search input to the orders page, allowing users to filter orders by a search term. Updates the API route and useOrders hook to support a 'search' parameter, and adds a new useDebounce hook for efficient input handling.
Search done by matching any parameter from the query result.