### PR TITLE
Add details functionality to orders page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -74,14 +74,14 @@ body {
   border-color: var(--border);
 }
 
-/* Podstawowe style dla przycisków */
+/* Basic styles for buttons */
 button,
 .button {
   border-radius: var(--radius);
   transition: all 0.2s ease-in-out;
 }
 
-/* Style dla inputów */
+/* Style for inputs */
 input,
 textarea,
 select {
@@ -98,7 +98,7 @@ select:focus {
   box-shadow: 0 0 0 2px rgba(173, 181, 189, 0.2);
 }
 
-/* Podstawowe animacje */
+/* Basic animations */
 .animate-fade {
   transition: opacity 0.3s ease-in-out;
 }
@@ -131,7 +131,7 @@ select:focus {
   background: var(--primary);
 }
 
-/* Dodatkowe style dla lepszej czytelności */
+/* Additional styles for better readability */
 .table-row-alternate:nth-child(even) {
   background-color: var(--muted);
 }
@@ -145,7 +145,7 @@ select:focus {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
 }
 
-/* Style dla nagłówków */
+/* Header styles */
 h1,
 h2,
 h3,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,7 +18,22 @@
   --ring: #adb5bd;
   --radius: 0.5rem;
 }
+@layer utilities {
+  .animate-slideDown {
+    animation: slideDown 0.3s ease-out;
+  }
 
+  @keyframes slideDown {
+    from {
+      opacity: 0;
+      transform: translateY(-4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+}
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,9 +16,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="pl">
       <body className={inter.className}>
         <Providers>
-          <div className="flex min-h-screen bg-background">
-            <Sidebar />
-            <main className="flex-1 lg:ml-64">{children}</main>
+          <div className="relative min-h-screen bg-background">
+            {/* Sidebar z absolutnym pozycjonowaniem i stałą szerokością */}
+            <div className="relative min-h-screen bg-background">
+              <Sidebar />
+              <main className="lg:pl-64 overflow-x-hidden min-h-screen">{children}</main>
+            </div>
           </div>
         </Providers>
       </body>

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -105,110 +105,110 @@ export default function OrdersPage() {
         ) : orders.length === 0 ? (
           <div className="text-center py-12 text-muted-foreground">Brak zamówień do wyświetlenia</div>
         ) : (
-          <>
-            <div className="overflow-x-auto rounded-lg border border-border">
-              <table className="min-w-full divide-y divide-border">
-                <thead className="bg-muted">
-                  <TableHeaderRow
-                    sortKey={sortKey ?? "created_at"}
-                    sortDirection={sortDirection}
-                    statusSortDirection={statusSortDirection}
-                    productSortDirection={productSortDirection}
-                    onSortDate={() => {
-                      setSortKey("created_at");
-                      setSortDirection((prev) => (sortKey === "created_at" ? (prev === "asc" ? "desc" : "asc") : "desc"));
-                    }}
-                    onSortStatus={() => {
-                      setSortKey("status");
-                      setStatusSortDirection((prev) => (sortKey === "status" ? (prev === "asc" ? "desc" : "asc") : "asc"));
-                    }}
-                    onSortProduct={() => {
-                      setSortKey("size");
-                      setProductSortDirection((prev) => (sortKey === "size" ? (prev === "asc" ? "desc" : "asc") : "asc"));
-                    }}
-                    onSortPrice={() => {
-                      setSortKey("total_price");
-                      setSortDirection((prev) => (sortKey === "total_price" ? (prev === "asc" ? "desc" : "asc") : "desc"));
-                    }}
-                    statusButtonRef={statusButtonRef}
-                    showStatusDropdown={showStatusDropdown}
-                    setShowStatusDropdown={setShowStatusDropdown}
-                    allStatuses={allStatuses}
-                    onStatusFilter={setStatusFilter}
-                    statusFilter={statusFilter}
-                    productButtonRef={productButtonRef}
-                    showProductDropdown={showProductDropdown}
-                    setShowProductDropdown={setShowProductDropdown}
-                    allSizes={allSizes}
-                    onProductFilter={setProductFilter}
-                    productFilter={productFilter}
-                  />
-                </thead>
-                <tbody>
-                  {sortedOrders.map((order, index) => {
-                    const isSelected = selectedOrder?.id === order.id;
-                    return (
-                      <React.Fragment key={order.id || index}>
-                        <OrderRow
-                          order={order}
-                          index={index}
-                          getStatusColor={getStatusColor}
-                          formatDate={formatDate}
-                          formatPrice={formatPrice}
-                          onShowDetails={() => setSelectedOrder(isSelected ? null : order)}
-                        />
-                        {isSelected && (
-                          <tr className="bg-muted/10">
-                            <td colSpan={7} className="p-4 animate-slideDown transition-all">
-                              <div className="p-4 border border-border rounded-md bg-card">
-                                <h2 className="text-lg font-semibold mb-2">Szczegóły zamówienia #{order.id}</h2>
-                                <p>
-                                  <strong>Data:</strong> {formatDate(order.created_at)}
-                                </p>
-                                <p>
-                                  <strong>Status:</strong> <span className={`${getStatusColor(order.status)} px-2 py-1 rounded-full`}>{order.status}</span>
-                                </p>
-                                <p>
-                                  <strong>Klient:</strong> {order.contact_info?.first_name} {order.contact_info?.last_name}
-                                </p>
-                                <p>
-                                  <strong>Telefon:</strong> {order.contact_info?.phone || "-"}
-                                </p>
-                                <p>
-                                  <strong>Email:</strong> {order.contact_info?.email || "-"}
-                                </p>
-                                <p>
-                                  <strong>Adres:</strong> {order.contact_info?.street} {order.contact_info.house_number}, {order.contact_info?.postal_code} {order.contact_info?.city}
-                                </p>
-                                <p>
-                                  <strong>Dostawa:</strong> {order.delivery_option?.name}
-                                </p>
-                                <p>
-                                  <strong>Płatność:</strong> {order.payment_method?.name}
-                                </p>
-                                <p>
-                                  <strong>Rozmiar:</strong> {order.size?.name}
-                                </p>
-                                <p>
-                                  <strong>Dodatki:</strong> {order.additional_options?.length > 0 ? order.additional_options.map((o) => o.name).join(", ") : "Brak"}
-                                </p>
-                                <p>
-                                  <strong>Cena:</strong> {formatPrice(order.total_price)}
-                                </p>
-                                <button className="mt-4 px-4 py-2 bg-gray-800 text-white hover:bg-gray-700 rounded transition-colors" onClick={() => setSelectedOrder(null)}>
-                                  Zamknij
-                                </button>
-                              </div>
-                            </td>
-                          </tr>
-                        )}
-                      </React.Fragment>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          </>
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="min-w-full divide-y divide-border">
+              <thead className="bg-muted">
+                <TableHeaderRow
+                  sortKey={sortKey ?? "created_at"}
+                  sortDirection={sortDirection}
+                  statusSortDirection={statusSortDirection}
+                  productSortDirection={productSortDirection}
+                  onSortDate={() => {
+                    setSortKey("created_at");
+                    setSortDirection((prev) => (sortKey === "created_at" ? (prev === "asc" ? "desc" : "asc") : "desc"));
+                  }}
+                  onSortStatus={() => {
+                    setSortKey("status");
+                    setStatusSortDirection((prev) => (sortKey === "status" ? (prev === "asc" ? "desc" : "asc") : "asc"));
+                  }}
+                  onSortProduct={() => {
+                    setSortKey("size");
+                    setProductSortDirection((prev) => (sortKey === "size" ? (prev === "asc" ? "desc" : "asc") : "asc"));
+                  }}
+                  onSortPrice={() => {
+                    setSortKey("total_price");
+                    setSortDirection((prev) => (sortKey === "total_price" ? (prev === "asc" ? "desc" : "asc") : "desc"));
+                  }}
+                  statusButtonRef={statusButtonRef}
+                  showStatusDropdown={showStatusDropdown}
+                  setShowStatusDropdown={setShowStatusDropdown}
+                  allStatuses={allStatuses}
+                  onStatusFilter={setStatusFilter}
+                  statusFilter={statusFilter}
+                  productButtonRef={productButtonRef}
+                  showProductDropdown={showProductDropdown}
+                  setShowProductDropdown={setShowProductDropdown}
+                  allSizes={allSizes}
+                  onProductFilter={setProductFilter}
+                  productFilter={productFilter}
+                />
+              </thead>
+              <tbody>
+                {sortedOrders.map((order, index) => {
+                  const isSelected = selectedOrder?.id === order.id;
+                  return (
+                    <React.Fragment key={order.id || index}>
+                      <OrderRow
+                        order={order}
+                        index={index}
+                        getStatusColor={getStatusColor}
+                        formatDate={formatDate}
+                        formatPrice={formatPrice}
+                        onShowDetails={() => setSelectedOrder(isSelected ? null : order)}
+                      />
+                      {isSelected && (
+                        <tr className="bg-muted/10">
+                          <td colSpan={7} className="p-4 animate-slideDown transition-all">
+                            <div className="p-4 border border-border rounded-md bg-card">
+                              <h2 className="text-lg font-semibold mb-2">
+                                Szczegóły zamówienia <code className="font-normal text-base">#{order.id}</code>
+                              </h2>
+                              <p>
+                                <strong>Data:</strong> {formatDate(order.created_at)}
+                              </p>
+                              <p>
+                                <strong>Status:</strong> <span className={`${getStatusColor(order.status)} px-2 py-1 rounded-full`}>{order.status}</span>
+                              </p>
+                              <p>
+                                <strong>Klient:</strong> {order.contact_info?.first_name} {order.contact_info?.last_name}
+                              </p>
+                              <p>
+                                <strong>Telefon:</strong> {order.contact_info?.phone || "-"}
+                              </p>
+                              <p>
+                                <strong>Email:</strong> {order.contact_info?.email || "-"}
+                              </p>
+                              <p>
+                                <strong>Adres:</strong> {order.contact_info?.street} {order.contact_info?.house_number}, {order.contact_info?.postal_code} {order.contact_info?.city}
+                              </p>
+                              <p>
+                                <strong>Dostawa:</strong> {order.delivery_option?.name}
+                              </p>
+                              <p>
+                                <strong>Płatność:</strong> {order.payment_method?.name}
+                              </p>
+                              <p>
+                                <strong>Rozmiar:</strong> {order.size?.name}
+                              </p>
+                              <p>
+                                <strong>Dodatki:</strong> {order.additional_options?.length > 0 ? order.additional_options.map((o) => o.name).join(", ") : "Brak"}
+                              </p>
+                              <p>
+                                <strong>Cena:</strong> {formatPrice(order.total_price)}
+                              </p>
+                              <button className="mt-4 px-4 py-2 bg-gray-800 text-white hover:bg-gray-700 rounded border transition-colors cursor-pointer" onClick={() => setSelectedOrder(null)}>
+                                Zamknij
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </React.Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
     </AuthGuard>

--- a/src/components/orders/OrderRow.tsx
+++ b/src/components/orders/OrderRow.tsx
@@ -7,7 +7,7 @@ export const OrderRow = ({
   getStatusColor,
   formatDate,
   formatPrice,
-  onShowDetails, // funkcja do wyświetlania szczegółów
+  onShowDetails,
 }: {
   order: UIOrder;
   index: number;
@@ -17,7 +17,9 @@ export const OrderRow = ({
   onShowDetails: (order: UIOrder) => void;
 }) => (
   <tr className={index % 2 === 0 ? "bg-card" : "bg-muted/5"}>
-    <td className="px-4 py-4 whitespace-nowrap text-sm">{order.id || `#${index + 1}`}</td>
+    <td className="px-4 py-4 whitespace-nowrap text-sm">
+      <code>{order.id || `#${index + 1}`}</code>
+    </td>
     <td className="px-4 py-4 whitespace-nowrap text-sm">{formatDate(order.created_at)}</td>
     <td className="px-4 py-4 whitespace-nowrap">
       <span className={`px-2 py-1 text-xs font-medium rounded-full ${getStatusColor(order.status)}`}>{order.status}</span>
@@ -32,12 +34,12 @@ export const OrderRow = ({
       {order.additional_options.length > 0 && <span className="text-muted-foreground block">+ {order.additional_options.length} dodatki</span>}
     </td>
     <td className="px-4 py-4 whitespace-nowrap text-sm">{formatPrice(order.total_price)}</td>
-    <td className="px-4 py-4 whitespace-nowrap text-sm flex flex-col space-y-1">
-      <button onClick={() => onShowDetails(order)} className="text-primary hover:text-primary/80 transition-colors">
+    <td className="px-4 py-4 whitespace-nowrap text-sm flex flex-row space-y-1">
+      <button onClick={() => onShowDetails(order)} className="text-primary hover:text-primary/80 transition-colors border text-base px-2 py-2 mb-0 me-1 cursor-pointer">
         Szczegóły
       </button>
 
-      <button className="text-red-500 hover:text-red-600 transition-colors">Usuń</button>
+      <button className="text-red-500 hover:text-red-600 transition-colors border text-base px-2 py-2 ms-1 cursor-pointer">Usuń</button>
     </td>
   </tr>
 );

--- a/src/components/orders/OrderRow.tsx
+++ b/src/components/orders/OrderRow.tsx
@@ -1,35 +1,42 @@
 import React from "react";
 import { UIOrder } from "@/types/UIOrder";
 
-export const OrderRow = ({ order, index, getStatusColor, formatDate, formatPrice }: {
+export const OrderRow = ({
+  order,
+  index,
+  getStatusColor,
+  formatDate,
+  formatPrice,
+  onShowDetails, // funkcja do wyświetlania szczegółów
+}: {
   order: UIOrder;
   index: number;
   getStatusColor: (status: string) => string;
   formatDate: (dateString?: string) => string;
   formatPrice: (price: number) => string;
+  onShowDetails: (order: UIOrder) => void;
 }) => (
   <tr className={index % 2 === 0 ? "bg-card" : "bg-muted/5"}>
-    <td className="px-6 py-4 whitespace-nowrap text-sm">{order.id || `#${index + 1}`}</td>
-    <td className="px-6 py-4 whitespace-nowrap text-sm">{formatDate(order.created_at)}</td>
-    <td className="px-6 py-4 whitespace-nowrap">
+    <td className="px-4 py-4 whitespace-nowrap text-sm">{order.id || `#${index + 1}`}</td>
+    <td className="px-4 py-4 whitespace-nowrap text-sm">{formatDate(order.created_at)}</td>
+    <td className="px-4 py-4 whitespace-nowrap">
       <span className={`px-2 py-1 text-xs font-medium rounded-full ${getStatusColor(order.status)}`}>{order.status}</span>
     </td>
-    <td className="px-6 py-4 whitespace-nowrap text-sm">
+    <td className="px-4 py-4 whitespace-nowrap text-sm">
       {order.contact_info.first_name} {order.contact_info.last_name}
       <br />
       <span className="text-muted-foreground">{order.contact_info.phone || "-"}</span>
     </td>
-    <td className="px-6 py-4 whitespace-nowrap text-sm">
+    <td className="px-4 py-4 whitespace-nowrap text-sm">
       {order.size.name}
-      {order.additional_options.length > 0 && (
-        <span className="text-muted-foreground block">
-          + {order.additional_options.length} dodatki
-        </span>
-      )}
+      {order.additional_options.length > 0 && <span className="text-muted-foreground block">+ {order.additional_options.length} dodatki</span>}
     </td>
-    <td className="px-6 py-4 whitespace-nowrap text-sm">{formatPrice(order.total_price)}</td>
-    <td className="px-6 py-4 whitespace-nowrap text-sm">
-      <button className="text-primary hover:text-primary/80 transition-colors mr-2">Szczegóły</button>
+    <td className="px-4 py-4 whitespace-nowrap text-sm">{formatPrice(order.total_price)}</td>
+    <td className="px-4 py-4 whitespace-nowrap text-sm flex flex-col space-y-1">
+      <button onClick={() => onShowDetails(order)} className="text-primary hover:text-primary/80 transition-colors">
+        Szczegóły
+      </button>
+
       <button className="text-red-500 hover:text-red-600 transition-colors">Usuń</button>
     </td>
   </tr>

--- a/src/components/orders/TableHeaderCell.tsx
+++ b/src/components/orders/TableHeaderCell.tsx
@@ -29,7 +29,7 @@ type HeaderButtonProps = {
 };
 
 function HeaderButton({ label, onClick, variant, icon, buttonRef }: HeaderButtonProps) {
-  const baseClasses = "text-xs font-medium uppercase border border-border px-2 py-1 cursor-pointer hover:bg-muted/80";
+  const baseClasses = "text-sm font-medium uppercase border border-border px-2 py-1 cursor-pointer hover:bg-muted/80";
 
   const variantClasses = variant === "sort" ? "text-muted-foreground rounded flex items-center gap-1" : "text-sm rounded-l bg-muted flex items-center gap-1";
 
@@ -58,7 +58,7 @@ export function TableHeaderCell({
   funnel = false,
 }: TableHeaderCellProps) {
   return (
-    <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+    <th className="px-6 py-3 text-left font-medium text-muted-foreground uppercase tracking-wider">
       <div className="flex flex-col items-start space-y-1">
         {isFilterable && filterButtonRef && setShowDropdown && (
           <div className="relative">

--- a/src/components/orders/TableHeaderCell.tsx
+++ b/src/components/orders/TableHeaderCell.tsx
@@ -59,7 +59,7 @@ export function TableHeaderCell({
 }: TableHeaderCellProps) {
   return (
     <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-      <div className="flex items-center space-x-0.5">
+      <div className="flex flex-col items-start space-y-1">
         {isFilterable && filterButtonRef && setShowDropdown && (
           <div className="relative">
             <HeaderButton

--- a/src/types/UIOrder.ts
+++ b/src/types/UIOrder.ts
@@ -31,6 +31,7 @@ export interface UIOrder {
     phone: string;
     address?: string;
     street?: string;
+    house_number?: string;
     last_name: string;
     first_name: string;
     postal_code: string;


### PR DESCRIPTION
Added the ability to view order details by clicking a button on the orders page. When the button is clicked, detailed information about the selected order is displayed dynamically, improving the user experience by providing quick access to relevant data.

Closes #11 