### PR TITLE
Add analytics events table and display review consents

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,0 +1,137 @@
+"use client";
+import React, { useState, useMemo, useRef } from "react";
+import { Input } from "@/components/ui/input";
+import { Search, X } from "lucide-react";
+import { useAnalytics } from "@/hooks/useAnalytics";
+import { TableHeaderCell } from "@/components/orders/TableHeaderCell";
+
+export default function AnalyticsPage() {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [eventNameFilter, setEventNameFilter] = useState<string | undefined>(undefined);
+
+  const { events, loading, error } = useAnalytics();
+
+  const [sortColumn, setSortColumn] = useState<"timestamp" | "event_name" | "session_id" | undefined>(undefined);
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
+
+  const filterButtonRef = useRef<HTMLButtonElement | null>(null);
+  const [showEventNameDropdown, setShowEventNameDropdown] = useState(false);
+
+  function handleSort(column: "timestamp" | "event_name" | "session_id") {
+    if (sortColumn === column) {
+      setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortColumn(column);
+      setSortDirection("asc");
+    }
+  }
+
+  const eventNameOptions = useMemo(() => {
+    const uniqueNames = Array.from(new Set(events.map((e) => e.event_name))).sort();
+    return ["Wszystkie", ...uniqueNames];
+  }, [events]);
+
+  const filteredEvents = useMemo(() => {
+    let filtered = events.filter((event) => {
+      const searchTermLower = searchTerm.toLowerCase();
+      const matchesSearchTerm =
+        event.page_url.toLowerCase().includes(searchTermLower) || event.session_id.includes(searchTerm) || event.additional_data?.target_url?.toLowerCase().includes(searchTermLower);
+
+      const matchesEventNameFilter = eventNameFilter && eventNameFilter !== "Wszystkie" ? event.event_name === eventNameFilter : true;
+
+      return matchesSearchTerm && matchesEventNameFilter;
+    });
+
+    if (sortColumn) {
+      filtered = filtered.slice().sort((a, b) => {
+        let valA: string | number = a[sortColumn];
+        let valB: string | number = b[sortColumn];
+
+        if (sortColumn === "timestamp") {
+          valA = new Date(valA).getTime();
+          valB = new Date(valB).getTime();
+        } else {
+          valA = String(valA).toLowerCase();
+          valB = String(valB).toLowerCase();
+        }
+
+        if (valA < valB) return sortDirection === "asc" ? -1 : 1;
+        if (valA > valB) return sortDirection === "asc" ? 1 : -1;
+        return 0;
+      });
+    }
+
+    return filtered;
+  }, [events, searchTerm, eventNameFilter, sortColumn, sortDirection]);
+
+  return (
+    <div className="p-6">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold">Zdarzenia Analityczne</h1>
+        <div className="relative w-full max-w-md">
+          <Input placeholder="Szukaj po URL, session_id lub targeted_url..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} className="pl-8 pr-8" />
+          <Search className="absolute left-2.5 top-3 h-4 w-4 text-muted-foreground" />
+          {searchTerm && <X className="absolute right-2.5 top-3 h-4 w-4 text-muted-foreground cursor-pointer" onClick={() => setSearchTerm("")} />}
+        </div>
+      </div>
+
+      {error && <div className="mb-6 p-4 bg-red-100 border border-red-400 text-red-700 rounded-md">Błąd: {error}</div>}
+
+      {loading ? (
+        <div className="flex justify-center items-center h-64">
+          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary" />
+        </div>
+      ) : filteredEvents.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">Brak zdarzeń</div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-border bg-card shadow-sm">
+          <table className="min-w-full divide-y divide-border">
+            <thead className="bg-muted text-sm text-left text-muted-foreground">
+              <tr>
+                <TableHeaderCell label="Data" sortKey="timestamp" currentSortKey={sortColumn} sortDirection={sortDirection} onSort={() => handleSort("timestamp")} isSortable />
+                <TableHeaderCell
+                  label="Zdarzenie"
+                  sortKey="event_name"
+                  currentSortKey={sortColumn}
+                  sortDirection={sortDirection}
+                  onSort={() => handleSort("event_name")}
+                  isSortable
+                  isFilterable
+                  filterButtonRef={filterButtonRef}
+                  showDropdown={showEventNameDropdown}
+                  setShowDropdown={setShowEventNameDropdown}
+                  dropdownOptions={eventNameOptions}
+                  onFilter={(val) => setEventNameFilter(val === "Wszystkie" ? undefined : val)}
+                  filterValue={eventNameFilter}
+                  funnel
+                />
+                <th className="p-3 w-[400px]">Strona</th>
+                <TableHeaderCell label="Session ID" sortKey="session_id" currentSortKey={sortColumn} sortDirection={sortDirection} onSort={() => handleSort("session_id")} isSortable />
+                <th className="p-3">Dodatkowe dane</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-muted text-sm">
+              {filteredEvents.map((event, index) => (
+                <tr key={event.id} className={index % 2 === 0 ? "bg-muted/20" : ""}>
+                  <td className="p-3 whitespace-nowrap text-foreground">{new Date(event.timestamp).toLocaleString("pl-PL")}</td>
+                  <td className="p-3">{event.event_name}</td>
+                  <td className="p-3 text-blue-600 break-words max-w-[400px]">{event.page_url}</td>
+                  <td className="p-3">{event.session_id}</td>
+                  <td className="p-3 text-xs space-y-1 text-foreground">
+                    {Object.entries(event.additional_data || {})
+                      .filter(([_, value]) => value !== null && value !== "" && value !== undefined)
+                      .map(([key, value]) => (
+                        <div key={key}>
+                          <strong>{key.replace(/_/g, " ")}:</strong> {value}
+                        </div>
+                      ))}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -261,6 +261,10 @@ export default function OrdersPage() {
                                 <strong>Adres:</strong> {order.contact_info?.street} {order.contact_info?.house_number}, {order.contact_info?.postal_code} {order.contact_info?.city}
                               </p>
                               <p>
+                                <strong>Zgody:</strong>{" "}
+                                {order.consents?.feedback_contact ? (order.consents?.opinion_publication ? "Zgoda na kontakt oraz publikację opinii" : "Zgoda na kontakt") : "Brak"}
+                              </p>
+                              <p>
                                 <strong>Dostawa:</strong> {order.delivery_option?.name}
                               </p>
                               <p>

--- a/src/constants/menu.tsx
+++ b/src/constants/menu.tsx
@@ -1,4 +1,4 @@
-import { BarChart2, Package } from "lucide-react";
+import { BarChart2, Package, ChartBar } from "lucide-react";
 
 export const menuItems = [
   {
@@ -10,5 +10,10 @@ export const menuItems = [
     href: "/orders",
     label: "Zamówienia",
     icon: <Package className="w-5 h-5" />,
+  },
+  {
+    href: "/analytics",
+    label: "Analityka",
+    icon: <ChartBar className="w-5 h-5" />,
   },
 ];

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase/client";
+import { AnalyticsEvents } from "@/types/UIAnalyticsEvents";
+
+export function useAnalytics() {
+  const [events, setEvents] = useState<AnalyticsEvents[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchEvents() {
+      setLoading(true);
+      const { data, error } = await supabase.from("analytics_events").select("*");
+
+      if (error) {
+        console.error("Supabase error:", error.message);
+        setError(error.message);
+      } else {
+        setEvents(data as AnalyticsEvents[]);
+      }
+
+      setLoading(false);
+    }
+
+    fetchEvents();
+  }, []);
+
+  return { events, loading, error };
+}

--- a/src/types/UIAnalyticsEvents.ts
+++ b/src/types/UIAnalyticsEvents.ts
@@ -1,0 +1,15 @@
+export interface AnalyticsEvents {
+  id: string;
+  event_name: string;
+  timestamp: string;
+  session_id: string;
+  page_url: string;
+  additional_data: {
+    image_index: string;
+    image_alt: string;
+    button_text: string;
+    clicked_in: string;
+    target_url: string;
+    visible_ratio: string;
+  };
+}

--- a/src/types/UIOrder.ts
+++ b/src/types/UIOrder.ts
@@ -36,4 +36,8 @@ export interface UIOrder {
     first_name: string;
     postal_code: string;
   };
+  consets: {
+    feedback_contact: string;
+    opinion_publication: string;
+  };
 }


### PR DESCRIPTION
This PR adds UI components and logic for better visibility into analytics data and user consents:

- Introduced a new table to display recorded analytics events
- Includes filtering by event name and sorting by timestamp
- Updated the order view to show user review consents:
- Whether the user agreed to be contacted
- Whether the user consented to publishing their review

These improvements support transparency in data collection and help the team review user interactions more effectively.
